### PR TITLE
Fix symmetric masking and diagonal unit

### DIFF
--- a/data_processing/pretrain_dataset.py
+++ b/data_processing/pretrain_dataset.py
@@ -324,4 +324,7 @@ class Pretrain_Dataset(torch.utils.data.Dataset):
         input = self.convert_rgb(input,max_value)
         if self.transform is not None:
             input = self.transform(input)
+        # convert the diagonal position from pixel unit into patch unit
+        return_diag = int(return_diag / self.patch_size)
+        
         return list_to_tensor([input, mask_array, hic_count, return_diag,matrix_count])

--- a/model/models_hicfoundation.py
+++ b/model/models_hicfoundation.py
@@ -50,7 +50,7 @@ def apply_symmectric_noise(noise, diag):
                 row_end = N-cur_diag
                 col_end = N
             #make this region symmetric
-        cur_array[row_start:row_end, col_start:col_end] = cur_array[col_start:col_end, row_start:row_end]+cur_array[row_start:row_end, col_start:col_end].T
+        cur_array[row_start:row_end, col_start:col_end] = cur_array[row_start:row_end, col_start:col_end]+cur_array[row_start:row_end, col_start:col_end].T
         noise[k] = cur_array
     return noise
 class Models_HiCFoundation(nn.Module):


### PR DESCRIPTION
Changed the return_diag from unit of pixel into unit of patches, to be compatable with codes after dataloading.
Fix a bug in getting the symmetric mask when the HiC diagonal is a sub-diagonal in the window.